### PR TITLE
Add ml_alignment_kyh_v3 (Huber loss version) and update v2 own data s…

### DIFF
--- a/ml/ml_alignment_kyh_v2/preprocess_own_aligned.py
+++ b/ml/ml_alignment_kyh_v2/preprocess_own_aligned.py
@@ -13,39 +13,98 @@ ROOT = Path(__file__).resolve().parent
 
 
 def main():
-    input_path = ROOT.parent / "ml_XGboost" / "data" / "processed" / "own_processed_common.csv"
+    # own data 來源改成 features_all.csv
+    input_path = ROOT.parent / "ml_gru" / "features_all.csv"
     output_path = DATA_DIR / "own_processed_aligned.csv"
     schema_path = DATA_DIR / "common_features.json"
 
+    if not input_path.exists():
+        raise FileNotFoundError(f"找不到 own data 來源檔案: {input_path}")
+
+    print(f"[INFO] OWN DATA SOURCE: {input_path}")
+
     df = pd.read_csv(input_path)
 
-    required_cols = ["user_id", "date", "target"]
-    missing = [c for c in required_cols if c not in df.columns]
-    if missing:
-        raise ValueError(f"own_processed_common.csv 缺少必要欄位: {missing}")
+    # -------------------------------------------------
+    # 1. 欄位對應：future_expense_7d_sum 當成 target
+    # -------------------------------------------------
+    if "future_expense_7d_sum" not in df.columns:
+        raise ValueError(
+            "features_all.csv 缺少 future_expense_7d_sum 欄位，"
+            "無法建立 target。"
+        )
 
+    df = df.rename(columns={"future_expense_7d_sum": "target"})
+
+    # -------------------------------------------------
+    # 2. 檢查必要欄位
+    # -------------------------------------------------
+    required_cols = ["user_id", "date", "target"]
+    missing_required = [c for c in required_cols if c not in df.columns]
+    if missing_required:
+        raise ValueError(f"features_all.csv 缺少必要欄位: {missing_required}")
+
+    # -------------------------------------------------
+    # 3. 日期轉換
+    # -------------------------------------------------
     df = ensure_datetime(df, "date")
+
+    # -------------------------------------------------
+    # 4. 讀取 kaggle 對齊特徵
+    # -------------------------------------------------
+    if not schema_path.exists():
+        raise FileNotFoundError(
+            f"找不到 feature schema: {schema_path}\n"
+            "請先跑 preprocess_kaggle_common_aligned.py"
+        )
 
     common_features = load_feature_schema(schema_path)
 
+    # -------------------------------------------------
+    # 5. 檢查 features_all.csv 是否包含 v2 需要的共同特徵
+    # -------------------------------------------------
     missing_features = [c for c in common_features if c not in df.columns]
     if missing_features:
-        raise ValueError(f"own_processed_common.csv 缺少共同特徵欄位: {missing_features}")
+        raise ValueError(
+            "features_all.csv 缺少共同特徵欄位: "
+            f"{missing_features}\n"
+            "請確認 features_all.csv 欄位名稱是否和 v2 一致。"
+        )
 
+    # -------------------------------------------------
+    # 6. 補缺值
+    # -------------------------------------------------
     df = fill_missing_values(df)
 
-    # 用 log1p 壓縮 target 尺度
+    # -------------------------------------------------
+    # 7. 建立 label（沿用 v2：log1p）
+    # -------------------------------------------------
+    df["target"] = df["target"].clip(lower=0)
     df["label"] = np.log1p(df["target"])
 
+    # -------------------------------------------------
+    # 8. 只保留 v2 需要的欄位
+    # -------------------------------------------------
     final_cols = ["user_id", "date"] + common_features + ["target", "label"]
     df = df[final_cols].copy()
+
+    # 去除 label 空值
     df = df.dropna(subset=["label"]).reset_index(drop=True)
 
+    # -------------------------------------------------
+    # 9. 存檔
+    # -------------------------------------------------
     df.to_csv(output_path, index=False, encoding="utf-8-sig")
 
+    # -------------------------------------------------
+    # 10. Debug 輸出
+    # -------------------------------------------------
     print(f"[OK] saved aligned own data -> {output_path}")
+    print("\n[HEAD]")
     print(df.head())
-    print(df[common_features + ["target", "label"]].describe())
+
+    print("\n[STATS]")
+    print(df[common_features + ["target"]].describe())
 
 
 if __name__ == "__main__":

--- a/ml/ml_alignment_kyh_v3/alignment_utils.py
+++ b/ml/ml_alignment_kyh_v3/alignment_utils.py
@@ -1,0 +1,74 @@
+import json
+import pickle
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parent
+DATA_DIR = ROOT / "data" / "processed"
+MODEL_DIR = ROOT / "models"
+RESULT_DIR = ROOT / "results"
+
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+RESULT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+COMMON_FEATURES = [
+    "daily_expense",
+    "daily_income",
+    "txn_count",
+    "daily_net",
+    "dow",
+    "is_weekend",
+    "day",
+    "month",
+    "expense_7d_sum",
+    "expense_7d_mean",
+    "expense_30d_sum",
+    "expense_30d_mean",
+]
+
+
+def ensure_datetime(df, col):
+    df[col] = pd.to_datetime(df[col])
+    return df
+
+
+def fill_missing_values(df):
+    num_cols = df.select_dtypes(include=[np.number]).columns
+    df[num_cols] = df[num_cols].fillna(0)
+    return df
+
+
+def save_feature_schema(cols, path):
+    with open(path, "w") as f:
+        json.dump(cols, f)
+
+
+def load_feature_schema(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def save_pickle(obj, path):
+    with open(path, "wb") as f:
+        pickle.dump(obj, f)
+
+
+def load_pickle(path):
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def split_xy(df, features, target="label"):
+    return df[features], df[target]
+
+
+def train_valid_split_by_time(df, ratio=0.2):
+    df = df.sort_values("date")
+    split = int(len(df) * (1 - ratio))
+    return df[:split], df[split:]

--- a/ml/ml_alignment_kyh_v3/finetune_own_aligned.py
+++ b/ml/ml_alignment_kyh_v3/finetune_own_aligned.py
@@ -1,0 +1,97 @@
+import json
+import pandas as pd
+import xgboost as xgb
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+from alignment_utils import (
+    DATA_DIR,
+    MODEL_DIR,
+    RESULT_DIR,
+    load_feature_schema,
+    load_pickle,
+    split_xy,
+    train_valid_split_by_time,
+)
+
+
+def main():
+    own_data_path = DATA_DIR / "own_processed_aligned.csv"
+    base_model_path = MODEL_DIR / "xgb_kaggle_aligned_v3_huber_raw.json"
+    scaler_path = MODEL_DIR / "feature_scaler_v3_huber_raw.pkl"
+    finetuned_model_path = MODEL_DIR / "xgb_finetuned_own_aligned_v3_huber_raw.json"
+    metric_path = RESULT_DIR / "finetune_own_metrics_v3_huber_raw.json"
+    pred_path = RESULT_DIR / "own_valid_predictions_finetune_v3_huber_raw.csv"
+
+    df = pd.read_csv(own_data_path)
+    features = load_feature_schema(DATA_DIR / "common_features.json")
+
+    train_df, valid_df = train_valid_split_by_time(df, ratio=0.2)
+
+    X_train, y_train = split_xy(train_df, features, "label")
+    X_valid, y_valid = split_xy(valid_df, features, "label")
+
+    scaler = load_pickle(scaler_path)
+    X_train_sc = scaler.transform(X_train)
+    X_valid_sc = scaler.transform(X_valid)
+
+    model = xgb.XGBRegressor(
+        objective="reg:pseudohubererror",
+        n_estimators=100,
+        max_depth=4,
+        learning_rate=0.01,
+        subsample=0.7,
+        colsample_bytree=0.7,
+        reg_alpha=5.0,
+        reg_lambda=10.0,
+        min_child_weight=10,
+        gamma=1.0,
+        random_state=42,
+    )
+
+    if base_model_path.exists():
+        model.fit(
+            X_train_sc,
+            y_train,
+            xgb_model=str(base_model_path),
+            eval_set=[(X_valid_sc, y_valid)],
+            verbose=False,
+        )
+    else:
+        model.fit(
+            X_train_sc,
+            y_train,
+            eval_set=[(X_valid_sc, y_valid)],
+            verbose=False,
+        )
+
+    preds = model.predict(X_valid_sc)
+    preds = preds.clip(min=0)
+
+    metrics = {
+        "mae": float(mean_absolute_error(y_valid, preds)),
+        "rmse": float(mean_squared_error(y_valid, preds) ** 0.5),
+        "train_rows": int(len(train_df)),
+        "valid_rows": int(len(valid_df)),
+        "feature_count": int(len(features)),
+        "objective": "reg:pseudohubererror",
+        "target_space": "raw",
+    }
+
+    model.save_model(finetuned_model_path)
+
+    with open(metric_path, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2, ensure_ascii=False)
+
+    pred_df = valid_df[["user_id", "date", "target"]].copy()
+    pred_df["y_true"] = y_valid.values
+    pred_df["y_pred"] = preds
+    pred_df.to_csv(pred_path, index=False, encoding="utf-8-sig")
+
+    print(f"[OK] saved finetuned model -> {finetuned_model_path}")
+    print(f"[OK] saved metrics -> {metric_path}")
+    print(f"[OK] saved valid predictions -> {pred_path}")
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/ml_alignment_kyh_v3/preprocess_kaggle_common_aligned.py
+++ b/ml/ml_alignment_kyh_v3/preprocess_kaggle_common_aligned.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import pandas as pd
+
+from alignment_utils import (
+    DATA_DIR,
+    COMMON_FEATURES,
+    ensure_datetime,
+    fill_missing_values,
+    save_feature_schema,
+)
+
+ROOT = Path(__file__).resolve().parent
+
+
+def main():
+    input_path = ROOT.parent / "ml_XGboost" / "data" / "processed" / "kaggle_processed_common.csv"
+    output_path = DATA_DIR / "kaggle_processed_aligned.csv"
+    schema_path = DATA_DIR / "common_features.json"
+
+    df = pd.read_csv(input_path)
+
+    required_cols = ["user_id", "date", "target"]
+    missing = [c for c in required_cols if c not in df.columns]
+    if missing:
+        raise ValueError(f"kaggle_processed_common.csv 缺少必要欄位: {missing}")
+
+    df = ensure_datetime(df, "date")
+
+    missing_features = [c for c in COMMON_FEATURES if c not in df.columns]
+    if missing_features:
+        raise ValueError(f"kaggle_processed_common.csv 缺少共同特徵欄位: {missing_features}")
+
+    df = fill_missing_values(df)
+
+    df["target"] = df["target"].clip(lower=0)
+    df["label"] = df["target"]
+
+    final_cols = ["user_id", "date"] + COMMON_FEATURES + ["target", "label"]
+    df = df[final_cols].copy()
+    df = df.dropna(subset=["label"]).reset_index(drop=True)
+
+    df.to_csv(output_path, index=False, encoding="utf-8-sig")
+    save_feature_schema(COMMON_FEATURES, schema_path)
+
+    print(f"[OK] saved aligned kaggle data -> {output_path}")
+    print(f"[OK] saved feature schema -> {schema_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/ml_alignment_kyh_v3/preprocess_own_aligned.py
+++ b/ml/ml_alignment_kyh_v3/preprocess_own_aligned.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import pandas as pd
+
+from alignment_utils import (
+    DATA_DIR,
+    load_feature_schema,
+    ensure_datetime,
+    fill_missing_values,
+)
+
+ROOT = Path(__file__).resolve().parent
+
+
+def main():
+    input_path = ROOT.parent / "ml_XGboost" / "data" / "processed" / "own_processed_common.csv"
+    output_path = DATA_DIR / "own_processed_aligned.csv"
+    schema_path = DATA_DIR / "common_features.json"
+
+    df = pd.read_csv(input_path)
+
+    required_cols = ["user_id", "date", "target"]
+    missing = [c for c in required_cols if c not in df.columns]
+    if missing:
+        raise ValueError(f"own_processed_common.csv 缺少必要欄位: {missing}")
+
+    df = ensure_datetime(df, "date")
+
+    common_features = load_feature_schema(schema_path)
+
+    missing_features = [c for c in common_features if c not in df.columns]
+    if missing_features:
+        raise ValueError(f"own_processed_common.csv 缺少共同特徵欄位: {missing_features}")
+
+    df = fill_missing_values(df)
+
+    df["target"] = df["target"].clip(lower=0)
+    df["label"] = df["target"]
+
+    final_cols = ["user_id", "date"] + common_features + ["target", "label"]
+    df = df[final_cols].copy()
+    df = df.dropna(subset=["label"]).reset_index(drop=True)
+
+    df.to_csv(output_path, index=False, encoding="utf-8-sig")
+
+    print(f"[OK] saved aligned own data -> {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/ml_alignment_kyh_v3/run_pipeline_v3_huber.sh
+++ b/ml/ml_alignment_kyh_v3/run_pipeline_v3_huber.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "========== STEP 1: preprocess kaggle aligned =========="
+python3 preprocess_kaggle_common_aligned.py
+
+echo "========== STEP 2: preprocess own aligned =========="
+python3 preprocess_own_aligned.py
+
+echo "========== STEP 3: train kaggle base aligned (Huber raw target) =========="
+python3 train_kaggle_base_aligned.py
+
+echo "========== STEP 4: finetune on own aligned (Huber raw target) =========="
+python3 finetune_own_aligned.py
+
+echo "========== STEP 5: test transfer aligned (Huber raw target) =========="
+python3 test_transfer_aligned.py
+
+echo "========== DONE =========="

--- a/ml/ml_alignment_kyh_v3/test_transfer_aligned.py
+++ b/ml/ml_alignment_kyh_v3/test_transfer_aligned.py
@@ -1,0 +1,102 @@
+import json
+import pandas as pd
+import xgboost as xgb
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+from alignment_utils import (
+    DATA_DIR,
+    RESULT_DIR,
+    MODEL_DIR,
+    load_feature_schema,
+    load_pickle,
+)
+
+
+def evaluate_model(model_path, scaler, df, features, name):
+    X = df[features].copy()
+    y_raw = df["target"].copy()
+
+    X_sc = scaler.transform(X)
+
+    model = xgb.XGBRegressor()
+    model.load_model(model_path)
+
+    preds = model.predict(X_sc)
+    preds = preds.clip(min=0)
+
+    pred_df = df[["user_id", "date", "target"]].copy()
+    pred_df["y_true"] = y_raw.values
+    pred_df["y_pred"] = preds
+    pred_df.to_csv(
+        RESULT_DIR / f"predictions_{name}_v3_huber_raw.csv",
+        index=False,
+        encoding="utf-8-sig"
+    )
+
+    return {
+        "model_name": name,
+        "mae": float(mean_absolute_error(y_raw, preds)),
+        "rmse": float(mean_squared_error(y_raw, preds) ** 0.5),
+        "rows": int(len(df)),
+        "feature_count": int(len(features)),
+        "objective": "reg:pseudohubererror",
+        "target_space": "raw",
+    }
+
+
+def main():
+    own_data_path = DATA_DIR / "own_processed_aligned.csv"
+    schema_path = DATA_DIR / "common_features.json"
+    scaler_path = MODEL_DIR / "feature_scaler_v3_huber_raw.pkl"
+    base_model_path = MODEL_DIR / "xgb_kaggle_aligned_v3_huber_raw.json"
+    finetuned_model_path = MODEL_DIR / "xgb_finetuned_own_aligned_v3_huber_raw.json"
+
+    df = pd.read_csv(own_data_path)
+    features = load_feature_schema(schema_path)
+    scaler = load_pickle(scaler_path)
+
+    split_idx = int(len(df) * 0.8)
+    test_df = df.iloc[split_idx:].copy()
+
+    print("========== TEST INFO ==========")
+    print(f"Test size: {test_df.shape}")
+    print("Feature columns:")
+    print(features)
+    print("Test target summary:")
+    print(test_df["target"].describe())
+
+    results = []
+
+    if base_model_path.exists():
+        results.append(
+            evaluate_model(base_model_path, scaler, test_df, features, "base_aligned")
+        )
+
+    if finetuned_model_path.exists():
+        results.append(
+            evaluate_model(finetuned_model_path, scaler, test_df, features, "finetuned_aligned")
+        )
+
+    output_json = RESULT_DIR / "transfer_test_metrics_v3_huber_raw.json"
+    output_txt = RESULT_DIR / "aligned_results_v3_huber_raw.txt"
+
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+
+    with open(output_txt, "w", encoding="utf-8") as f:
+        for item in results:
+            f.write(
+                f"Model: {item['model_name']}\n"
+                f"Rows: {item['rows']}\n"
+                f"Feature count: {item['feature_count']}\n"
+                f"MAE: {item['mae']:.4f}\n"
+                f"RMSE: {item['rmse']:.4f}\n\n"
+            )
+
+    print(f"[OK] saved evaluation -> {output_json}")
+    print(f"[OK] saved summary -> {output_txt}")
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/ml_alignment_kyh_v3/train_kaggle_base_aligned.py
+++ b/ml/ml_alignment_kyh_v3/train_kaggle_base_aligned.py
@@ -1,0 +1,101 @@
+import json
+import pandas as pd
+import xgboost as xgb
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+from alignment_utils import (
+    DATA_DIR,
+    MODEL_DIR,
+    RESULT_DIR,
+    load_feature_schema,
+    save_pickle,
+    split_xy,
+    train_valid_split_by_time,
+)
+
+
+def main():
+    data_path = DATA_DIR / "kaggle_processed_aligned.csv"
+    model_path = MODEL_DIR / "xgb_kaggle_aligned_v3_huber_raw.json"
+    scaler_path = MODEL_DIR / "feature_scaler_v3_huber_raw.pkl"
+    metric_path = RESULT_DIR / "kaggle_base_metrics_v3_huber_raw.json"
+    pred_path = RESULT_DIR / "kaggle_valid_predictions_v3_huber_raw.csv"
+
+    df = pd.read_csv(data_path)
+    features = load_feature_schema(DATA_DIR / "common_features.json")
+
+    train_df, valid_df = train_valid_split_by_time(df, ratio=0.2)
+
+    X_train, y_train = split_xy(train_df, features, "label")
+    X_valid, y_valid = split_xy(valid_df, features, "label")
+
+    scaler = StandardScaler()
+    X_train_sc = scaler.fit_transform(X_train)
+    X_valid_sc = scaler.transform(X_valid)
+    save_pickle(scaler, scaler_path)
+
+    print("========== TRAIN INFO ==========")
+    print(f"Train size: {X_train.shape}, Valid size: {X_valid.shape}")
+    print("Feature columns:")
+    print(features)
+    print("Train label summary (raw space):")
+    print(y_train.describe())
+    print("Valid label summary (raw space):")
+    print(y_valid.describe())
+
+    model = xgb.XGBRegressor(
+        objective="reg:pseudohubererror",
+        n_estimators=200,
+        max_depth=4,
+        learning_rate=0.01,
+        subsample=0.7,
+        colsample_bytree=0.7,
+        reg_alpha=5.0,
+        reg_lambda=10.0,
+        min_child_weight=10,
+        gamma=1.0,
+        random_state=42,
+    )
+
+    model.fit(
+        X_train_sc,
+        y_train,
+        eval_set=[(X_valid_sc, y_valid)],
+        verbose=False,
+    )
+
+    preds = model.predict(X_valid_sc)
+
+    # 原始 target 空間下，限制極端值
+    preds = preds.clip(min=0)
+
+    metrics = {
+        "mae": float(mean_absolute_error(y_valid, preds)),
+        "rmse": float(mean_squared_error(y_valid, preds) ** 0.5),
+        "train_rows": int(len(train_df)),
+        "valid_rows": int(len(valid_df)),
+        "feature_count": int(len(features)),
+        "objective": "reg:pseudohubererror",
+        "target_space": "raw",
+    }
+
+    model.save_model(model_path)
+
+    with open(metric_path, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2, ensure_ascii=False)
+
+    pred_df = valid_df[["user_id", "date", "target"]].copy()
+    pred_df["y_true"] = y_valid.values
+    pred_df["y_pred"] = preds
+    pred_df.to_csv(pred_path, index=False, encoding="utf-8-sig")
+
+    print(f"[OK] saved model -> {model_path}")
+    print(f"[OK] saved scaler -> {scaler_path}")
+    print(f"[OK] saved metrics -> {metric_path}")
+    print(f"[OK] saved valid predictions -> {pred_path}")
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 摘要
本次更新 alignment 流程，並新增使用 Huber loss 的模型版本（v3），提升模型穩定性。

## 主要變更
- v2：將 own dataset 改為 `features_all.csv`，並使用 `future_expense_7d_sum` 作為 target
- v3：新增 Huber loss（reg:pseudohubererror）模型與完整訓練流程

## 目的
- 降低 Kaggle 與 own dataset 的分布差異
- 提升模型對極端值（outliers）的穩健性