### PR TITLE
將 transformer TL 模型的 SEEDS 補齊至 30 個

### DIFF
--- a/ml/transformer_TL_alignment/4_finetune_transformer.py
+++ b/ml/transformer_TL_alignment/4_finetune_transformer.py
@@ -31,7 +31,12 @@ WEIGHT_DECAY  = 1e-4
 HUBER_DELTA   = 1.0
 MMD_LAMBDA    = 0.1
 
-SEEDS = [42, 123, 777, 456, 789, 999, 2024]
+SEEDS = [
+    42, 123, 777, 456, 789, 999, 2024,
+    0, 7, 13, 21, 100, 314, 1234, 9999,
+    11, 22, 33, 44, 55, 66, 77, 88, 99,
+    111, 222, 333, 444, 555, 666
+]
 
 if torch.cuda.is_available():
     device = torch.device("cuda")

--- a/ml_ibm/transformer_TL_alignment/4_finetune_transformer.py
+++ b/ml_ibm/transformer_TL_alignment/4_finetune_transformer.py
@@ -30,7 +30,12 @@ PATIENCE      = 10
 WEIGHT_DECAY  = 1e-4
 HUBER_DELTA   = 1.0
 
-SEEDS = [42, 123, 777, 456, 789, 999, 2024]
+SEEDS = [
+    42, 123, 777, 456, 789, 999, 2024,
+    0, 7, 13, 21, 100, 314, 1234, 9999,
+    11, 22, 33, 44, 55, 66, 77, 88, 99,
+    111, 222, 333, 444, 555, 666
+]
 
 device = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
 print(f"⚙️  使用設備: {device}")


### PR DESCRIPTION
## 變更內容

將以下兩個 transformer finetune 腳本的 `SEEDS` 從 7 個擴充至 30 個：

- `ml/transformer_TL_alignment/4_finetune_transformer.py`
- `ml_ibm/transformer_TL_alignment/4_finetune_transformer.py`

## 原因

其他六個模型（ml/gru、ml/bigru、ml/bilstm、ml_ibm/gru、ml_ibm/bigru、ml_ibm/bilstm）皆已使用 30 個 seeds，transformer 模型遺漏未更新，此 PR 補齊以確保八個模型實驗條件一致。

## 新 SEEDS 列表

```python
SEEDS = [
    42, 123, 777, 456, 789, 999, 2024,
    0, 7, 13, 21, 100, 314, 1234, 9999,
    11, 22, 33, 44, 55, 66, 77, 88, 99,
    111, 222, 333, 444, 555, 666
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)